### PR TITLE
3,4章の内容をjsonファイルに記入

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ from flask import Flask
 from flask_cors import CORS
 from app.db import db
 from app.develop import develop_page
+from app.story import story_page
 
 app = Flask(__name__)
 CORS(app)
@@ -11,5 +12,6 @@ app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db.sqlite'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 app.register_blueprint(develop_page)
+app.register_blueprint(story_page)
 
 db.init_app(app)

--- a/app/db.py
+++ b/app/db.py
@@ -16,13 +16,15 @@ class Item(db.Model):
 
 class Choices(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    choice = db.Column(db.String(80), nullable=False)
+    chapter = db.Column(db.Integer, nullable=False)
+    choice = db.Column(db.Integer, nullable=False)
 
-    def __init__(self, choice):
+    def __init__(self, chapter, choice):
+        self.chapter = chapter
         self.choice = choice
 
     def __repr__(self):
-        return f'<Choices {self.index}>'
+        return f'<Choices {self.id}>'
 
 # データベースの初期化
 def init_db(app):

--- a/app/db.py
+++ b/app/db.py
@@ -13,6 +13,17 @@ class Item(db.Model):
     def __repr__(self):
         return f'<Item {self.name}>'
 
+
+class Choices(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    choice = db.Column(db.String(80), nullable=False)
+
+    def __init__(self, choice):
+        self.choice = choice
+
+    def __repr__(self):
+        return f'<Choices {self.index}>'
+
 # データベースの初期化
 def init_db(app):
     with app.app_context():

--- a/app/story.py
+++ b/app/story.py
@@ -1,0 +1,18 @@
+from flask import jsonify, request
+from flask import Blueprint
+from app.db import db, Choices
+import json
+import os
+
+
+story_page = Blueprint('story', __name__)
+
+@story_page.route('/story/3', methods=['GET'])
+def send_chapter3():
+    file_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'story', 'chapter3.json')
+
+    # JSONファイルを読み込んで返す
+    with open(file_path, 'r', encoding='utf-8') as file:
+        chapter3_data = json.load(file)
+    
+    return jsonify(chapter3_data)

--- a/app/story.py
+++ b/app/story.py
@@ -16,3 +16,19 @@ def send_chapter3():
         chapter3_data = json.load(file)
     
     return jsonify(chapter3_data)
+
+
+@story_page.route('/story/save', methods=['POST'])
+def save_branch():
+    data = request.get_json()
+    print("受信したデータ:", data)
+
+    choice_num = data.get('choice')
+    chapter_num = data.get('chapter')
+
+    # choice_num = request.json['choice']
+    # chapter_num = request.json['chapter']
+    new_choices = Choices(choice=choice_num, chapter=chapter_num)
+    db.session.add(new_choices)
+    db.session.commit()
+    return jsonify(str(new_choices)), 201

--- a/data/story/chapter3.json
+++ b/data/story/chapter3.json
@@ -1,0 +1,191 @@
+[
+    {
+        "index": 1,
+        "state": false,
+        "people": 0,
+        "sentence": "第三章 -冷酷の国- 永遠の冬に包まれ、住民たちは凍りついた感情で生きている。"
+    },
+    {
+        "index": 2,
+        "state": false,
+        "people": 1,
+        "sentence": "ここ寒すぎる…凍死しそう"
+    },
+    {
+        "index": 3,
+        "state": false,
+        "people": 1,
+        "sentence": "へっっっっっっくしゅん……"
+    },
+    {
+        "index": 4,
+        "state": false,
+        "people": 1,
+        "sentence": "ジュエルのかけらはこの国の女王様が持っているらしい"
+    },
+    {
+        "index": 5,
+        "state": false,
+        "people": 1,
+        "sentence": "この国の女王様に会いに行こう"
+    },
+    {
+        "index": 6,
+        "state": false,
+        "people": 0,
+        "sentence": "シーン：王宮に入る"
+    },
+    {
+        "index": 7,
+        "state": false,
+        "people": 2,
+        "sentence": "私はこの国を支配する女王だ"
+    },
+    {
+        "index": 8,
+        "state": false,
+        "people": 2,
+        "sentence": "何の用だ"
+    },
+    {
+        "index": 9,
+        "state": false,
+        "people": 1,
+        "sentence": "あなたがジュエルのかけらを持っていると分かり、はるばる鏡の国からやってきました"
+    },
+    {
+        "index": 10,
+        "state": false,
+        "people": 1,
+        "sentence": "そこでお願いなのですが…………ジュエルのかけらを譲っていただきたくて…………"
+    },
+    {
+        "index": 11,
+        "state": false,
+        "people": 1,
+        "sentence": "もしダメなら借りるだけでも…"
+    },
+    {
+        "index": 12,
+        "state": false,
+        "people": 2,
+        "sentence": "なぜだ"
+    },
+    {
+        "index": 13,
+        "state": false,
+        "people": 1,
+        "sentence": "夢の中の誰かが言っていたんです。ジュエルのかけらを全て集めると、世界の真実にたどり着けるだろう、と…"
+    },
+    {
+        "index": 14,
+        "state": false,
+        "people": 2,
+        "sentence": "なるほど"
+    },
+    {
+        "index": 15,
+        "state": false,
+        "people": 2,
+        "sentence": "似たような夢を、以前私も見た"
+    },
+    {
+        "index": 16,
+        "state": false,
+        "people": 2,
+        "sentence": "今日お前が来ることを私は知っていた"
+    },
+    {
+        "index": 17,
+        "state": false,
+        "people": 1,
+        "sentence": "？！"
+    },
+    {
+        "index": 18,
+        "state": false,
+        "people": 2,
+        "sentence": "私はかつて、信頼していた者から裏切られ、ジュエルによってこの国の感情を封じた"
+    },
+    {
+        "index": 19,
+        "state": false,
+        "people": 2,
+        "sentence": "私の心も同様だ。凍ったままだ"
+    },
+    {
+        "index": 20,
+        "state": false,
+        "people": 2,
+        "sentence": "再び心を溶かすわけにはいかない、そして支配を終わらせるわけにはいかない"
+    },
+    {
+        "index": 21,
+        "state": false,
+        "people": 1,
+        "sentence": "すぐに手に入れるのは無理そうだ、どうしよう"
+    },
+    {
+        "index": 22,
+        "state": true,
+        "people": 1,
+        "sentence": [
+            {
+                "id": 1,
+                "content": "女王と対話し、和解を試みる"
+            },
+            {
+                "id": 2,
+                "content": "女王を倒し、国を解放する"
+            }
+        ]
+    },
+    {
+        "index": 23,
+        "state": false,
+        "people": 1,
+        "sentence": "本当に心が凍ったままでいいのですか？過去に何があったのか、教えてくれませんか？"
+    },
+    {
+        "index": 24,
+        "state": false,
+        "people": 2,
+        "sentence": "あなたは悪い人に見えない。私には分かる。過去に何があったのか話そう……………"
+    },
+    {
+        "index": 25,
+        "state": false,
+        "people": 2,
+        "sentence": "君が私にそう言うならば、心を解き放つことにしよう。"
+    },
+    {
+        "index": 26,
+        "state": false,
+        "people": 2,
+        "sentence": "だが、私がかつての痛みと向き合うために、またこの国も変わるだろう"
+    },
+    {
+        "index": 27,
+        "state": false,
+        "people": 0,
+        "sentence": "和解できたが、真実の詳細を知ることは無かった。ジュエルのかけらを手に入れた。"
+    },
+    {
+        "index": 28,
+        "state": false,
+        "people": 1,
+        "sentence": "感情を取り戻すことができないなら、あなたを止めるしかない。国のために、君の支配を終わらせる！"
+    },
+    {
+        "index": 29,
+        "state": false,
+        "people": 2,
+        "sentence": "来るがいい。その選択もまた、自由だ。私を倒すことが国の救いだと思うなら"
+    },
+    {
+        "index": 30,
+        "state": false,
+        "people": 0,
+        "sentence": "ジュエルのかけらを手に入れた。氷の女王を倒したことにより、グレンツェは真実を知ることになる。それは、自分の一族が、かつて世界の分断を招いたことを"
+    }
+]

--- a/data/story/chapter3.json
+++ b/data/story/chapter3.json
@@ -15,7 +15,7 @@
         "index": 3,
         "state": false,
         "people": 1,
-        "sentence": "へっっっっっっくしゅん……"
+        "sentence": "へっくしゅん……"
     },
     {
         "index": 4,
@@ -132,11 +132,15 @@
         "sentence": [
             {
                 "id": 1,
-                "content": "女王と対話し、和解を試みる"
+                "content": "女王と対話し、和解を試みる",
+                "start": 22,
+                "end": 26
             },
             {
                 "id": 2,
-                "content": "女王を倒し、国を解放する"
+                "content": "女王を倒し、国を解放する",
+                "start": 27,
+                "end": 29
             }
         ]
     },

--- a/data/story/chapter4.json
+++ b/data/story/chapter4.json
@@ -1,0 +1,137 @@
+[
+    {
+        "index": 1,
+        "state": false,
+        "people": 0,
+        "sentence": "第四章 -幻想の国- 濃い霧に包まれた世界。住民たちはジュエルの影響で、次第に自分の記憶を失い、穏やかな忘却に浸っている。"
+    },
+    {
+        "index": 2,
+        "state": false,
+        "people": 1,
+        "sentence": "この国に入ってから、頭がぼーーっとするや"
+    },
+    {
+        "index": 3,
+        "state": false,
+        "people": 1,
+        "sentence": "でも、景色が綺麗な国だ"
+    },
+    {
+        "index": 4,
+        "state": false,
+        "people": 0,
+        "sentence": "数日後"
+    },
+    {
+        "index": 5,
+        "state": false,
+        "people": 1,
+        "sentence": "この国の人は、過去の出来事を忘れている"
+    },
+    {
+        "index": 6,
+        "state": false,
+        "people": 1,
+        "sentence": "一体どうなっているんだ"
+    },
+    {
+        "index": 7,
+        "state": false,
+        "people": 3,
+        "sentence": "そうだよ。僕は過去のことは何もかも忘れた、それが幸せだけれどね"
+    },
+    {
+        "index": 8,
+        "state": false,
+        "people": 1,
+        "sentence": "！！…急にびっくりした…"
+    },
+    {
+        "index": 9,
+        "state": false,
+        "people": 3,
+        "sentence": "突然ごめんね。早くこの国から出た方が良いよ"
+    },
+    {
+        "index": 10,
+        "state": false,
+        "people": 1,
+        "sentence": "え？"
+    },
+    {
+        "index": 11,
+        "state": false,
+        "people": 3,
+        "sentence": "君は他の国から来た人でしょ？早く出ないと何もかも忘れちゃうよ"
+    },
+    {
+        "index": 12,
+        "state": false,
+        "people": 1,
+        "sentence": "まだやることがあるから出られないよ"
+    },
+    {
+        "index": 13,
+        "state": false,
+        "people": 1,
+        "sentence": "君たちは大事なことを忘れたままで良いの？"
+    },
+    {
+        "index": 14,
+        "state": false,
+        "people": 3,
+        "sentence": "………"
+    },
+    {
+        "index": 15,
+        "state": true,
+        "people": 1,
+        "sentence": [
+            {
+                "id": 1,
+                "content": "冒険の記憶と引き換えに、住民たちの記憶を取り戻す"
+            },
+            {
+                "id": 2,
+                "content": "住民たちの記憶を失わせたままにする"
+            }
+        ]
+    },
+    {
+        "index": 16,
+        "state": false,
+        "people": 1,
+        "sentence": "過去を忘れてはいけない。君たちは記憶を取り戻すべきだ。きっと大切な過去があったはずだ。"
+    },
+    {
+        "index": 17,
+        "state": false,
+        "people": 3,
+        "sentence": "君の言葉を信じることにする。"
+    },
+    {
+        "index": 18,
+        "state": false,
+        "people": 0,
+        "sentence": "ジュエルのかけらが光りだし、一つになった。"
+    },
+    {
+        "index": 19,
+        "state": false,
+        "people": 1,
+        "sentence": "君たちにとって、過去を忘れることが幸せなんだろ？このままで良いんだ…"
+    },
+    {
+        "index": 20,
+        "state": false,
+        "people": 3,
+        "sentence": "そう…僕たちは、このままで良いんだ。何も思い出さずに…"
+    },
+    {
+        "index": 21,
+        "state": false,
+        "people": 0,
+        "sentence": "虚無の平穏が訪れた"
+    }
+]


### PR DESCRIPTION
## やったこと
- ３、４章のjsonファイル作成
- 3章の内容のapi作成
- 選択肢が保存されるよう設定

## 変更点
具体的な変更点や修正箇所を箇条書きでリストアップ

- ３、４章のjsonファイル作成
- ３章のjsonファイルを送るapi作成
- 選択した結果をdbに保存

## 動作確認
スクショや動画で動作確認をした画面を貼り付け

## まだやってないこと
あれば記入
- 他の章に対応させる
- ３章以外の分岐以降の始点と終点を設定する
- ユーザごとに保存
- 選択肢の上書き

## 伝えときたいこと
- 

## 関連Issue
- Issue: #14 
